### PR TITLE
Stricter type checking among `object` types

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /*!
  * deep-diff.
  * Licensed under the MIT License.
- */ 
+ */
 /*jshint indent:2, laxcomma:true*/
 ;(function (undefined) {
   "use strict";
@@ -79,6 +79,26 @@
     return arr;
   }
 
+  function realTypeOf(subject) {
+    var type = typeof subject;
+    if (type !== 'object') {
+      return type;
+    }
+
+    if (subject === Math) {
+      return 'math';
+    } else if (subject === null) {
+      return 'null';
+    } else if (Array.isArray(subject)) {
+      return 'array';
+    } else if (subject instanceof Date) {
+      return 'date';
+    } else if (/^\/.*\//.test(subject.toString())) {
+      return 'regexp';
+    }
+    return 'object';
+  }
+
   function deepDiff(lhs, rhs, changes, prefilter, path, key, stack) {
     path = path || [];
     var currentPath = path.slice(0);
@@ -94,7 +114,7 @@
       }
     } else if (rtype === 'undefined') {
       changes(new DiffDeleted(currentPath, lhs));
-    } else if (ltype !== rtype) {
+    } else if (realTypeOf(lhs) !== realTypeOf(rhs)) {
       changes(new DiffEdit(currentPath, lhs, rhs));
     } else if (lhs instanceof Date && rhs instanceof Date && ((lhs - rhs) !== 0)) {
       changes(new DiffEdit(currentPath, lhs, rhs));

--- a/test/tests.js
+++ b/test/tests.js
@@ -20,6 +20,33 @@ describe('deep-diff', function () {
       expect(deep.diff(empty, {})).to.be.an('undefined');
     });
 
+    describe('when compared to a different type of keyless object', function () {
+      var ctor = function () {
+        this.foo = 'bar';
+      };
+      var comparandTuples = [['an array', { key: [] }],
+                             ['an object', { key: {}}],
+                             ['a date', { key: new Date() }],
+                             ['a null', { key: null }],
+                             ['a regexp literal', {key: /a/}],
+                             ['Math', {key: Math}]];
+
+      comparandTuples.forEach(function (lhsTuple) {
+        comparandTuples.forEach(function (rhsTuple) {
+          if (lhsTuple[0] === rhsTuple[0]) {
+            return;
+          }
+          it('shows differences when comparing ' + lhsTuple[0] + ' to ' + rhsTuple[0], function () {
+            var diff = deep.diff(lhsTuple[1], rhsTuple[1]);
+            expect(diff).to.be.ok();
+            expect(diff.length).to.be(1);
+            expect(diff[0]).to.have.property('kind');
+            expect(diff[0].kind).to.be('E');
+          });
+        });
+      });
+    });
+
     describe('when compared with an object having other properties', function () {
       var comparand = { other: 'property', another: 13.13 };
       var diff = deep.diff(empty, comparand);
@@ -66,6 +93,14 @@ describe('deep-diff', function () {
 
     it('shows the property as edited when compared to an object with null', function () {
       var diff = deep.diff(lhs, { one: null });
+      expect(diff).to.be.ok();
+      expect(diff.length).to.be(1);
+      expect(diff[0]).to.have.property('kind');
+      expect(diff[0].kind).to.be('E');
+    });
+
+    it ('shows the property as edited when compared to an array', function () {
+      var diff = deep.diff(lhs, ['one']);
       expect(diff).to.be.ok();
       expect(diff.length).to.be(1);
       expect(diff[0]).to.have.property('kind');


### PR DESCRIPTION
Hi there! I've been getting some unexpected results when types change between different flavors of `object`:

```javascript
var dd = require('deep-diff');

dd([], {})
// => undefined

dd({}, /surely these are different!/gi)
// => undefined

dd(['a','b','c'], {a:1, b:1, c:1})
// => [ { kind: 'D',
// =>    path: [ 0 ],
// =>    lhs: 'a' },
// =>  { kind: 'D',
// =>    path: [ 1 ],
// =>    lhs: 'b' },
// =>  { kind: 'D',
// =>    path: [ 2 ],
// =>    lhs: 'c' } ]

dd({a:1}, [1])
// => [ { kind: 'D',
// =>     path: [ 'a' ],
// =>     lhs: 1 },
// =>   { kind: 'N',
// =>     path: [ '0' ],
// =>     rhs: 1 } ]

```

Here's a patch that inspects `object`s a little more closely and reports type changes such as `{} -> []` as kind `E`.
