### PR TITLE
Update dependecies, and build on latest Node as well as Io.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ branches:
   only:
     - master
 node_js:
+  - "iojs"
+  - "0.12"
   - "0.11"
   - "0.10"
   - "0.8"

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "test": "./test"
   },
   "devDependencies": {
-    "deep-equal": "~0.2.1",
+    "deep-equal": "~1.0.0",
     "expect.js": "~0.3.1",
-    "mocha": "~1.17.1"
+    "mocha": "~2.2.1"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha -R spec"
+    "test": "mocha -R spec"
   }
 }


### PR DESCRIPTION
npm run-script autmatically adds node_modules/.bin to path, so it's possible to call Mocha directly