### PR TITLE
Fix for issue #35 -- apply diffs for arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,7 +249,7 @@
     if (target && source && change && change.kind) {
       var it = target,
         i = -1,
-        last = change.path.length - 1;
+        last = change.path ? change.path.length - 1 : 0;
       while (++i < last) {
         if (typeof it[change.path[i]] === 'undefined') {
           it[change.path[i]] = (typeof change.path[i] === 'number') ? [] : {};
@@ -258,7 +258,7 @@
       }
       switch (change.kind) {
         case 'A':
-          applyArrayChange(it[change.path[i]], change.index, change.item);
+          applyArrayChange(change.path ? it[change.path[i]] : it, change.index, change.item);
           break;
         case 'D':
           delete it[change.path[i]];

--- a/test/tests.js
+++ b/test/tests.js
@@ -482,4 +482,22 @@ describe('deep-diff', function() {
 
     });
 
+    describe('regression test for bug #35', function() {
+        var lhs = ["a", "a", "a"];
+        var rhs = ["a"];
+
+        it('can apply diffs between two top level arrays', function() {
+            var differences = deep.diff(lhs, rhs);
+
+            /* We must apply the differences in reverse order, since the array indices 
+               in the diff become stale/invalid if you delete elements from the array
+               whose indices are in ascending order */
+            for (var i = differences.length - 1; i >= 0; i--) {
+                deep.applyChange(lhs, true, differences[i]);
+            }
+
+            expect(lhs).to.eql(["a"]);
+        });
+    });
+
 });


### PR DESCRIPTION
This is a fix for Issue #35. The problem was that the applyChange function was assuming that the change object would have a path associated with it. However, that is not the case when the top-level objects that are being compared are arrays.

The code in this pull request is minimal and is designed so that there is no way it alters existing behavior in any way except for fixing the bug.

All tests pass.