### PR TITLE
fix wrong 'undefined' definition under almond.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,9 @@
   'use strict';
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define([], factory);
+    define([], function() {
+      return factory();
+    });
   } else if (typeof exports === 'object') {
     // Node. Does not work with strict CommonJS, but
     // only CommonJS-like environments that support module.exports,


### PR DESCRIPTION
'almond' will inject ['require', 'exports', 'module'] dependences, if we define the module with a empty 'deps'. That means the first argument of factory would be 'require' function, rather than the 'undefined' we expected.