### PR TITLE
Modification to make array diff order independent. 

### DIFF
--- a/index.es.js
+++ b/index.es.js
@@ -18,6 +18,8 @@ if (conflict) {
     });
 }
 
+var ignoreOrder = false;
+
 // nodejs compatible on server side and in the browser.
 function inherits(ctor, superCtor) {
   ctor.super_ = superCtor;
@@ -115,7 +117,7 @@ function realTypeOf(subject) {
   return 'object';
 }
 
-function deepDiff(lhs, rhs, changes, prefilter, path, key, stack) {
+function deepDiff(lhs, rhs, changes, prefilter, path, key, stack, orderIndependent) {
   path = path || [];
   stack = stack || [];
   var currentPath = path.slice(0);
@@ -162,16 +164,37 @@ function deepDiff(lhs, rhs, changes, prefilter, path, key, stack) {
         return x.lhs === lhs; }).length) {
       stack.push({ lhs: lhs, rhs: rhs });
       if (Array.isArray(lhs)) {
-        var i, len = lhs.length;
-        for (i = 0; i < lhs.length; i++) {
-          if (i >= rhs.length) {
-            changes(new DiffArray(currentPath, i, new DiffDeleted(undefined, lhs[i])));
+        var lhs1 = Array.from(lhs); 
+		var rhs1 = Array.from(rhs);
+		if (orderIndependent) {
+			for (i = 0; i < lhs.length && rhs1.length > 0 && lhs1.length > 0; i++) {
+				var ridx = rhs1.indexOf(lhs[i]);
+				var lidx = lhs1.indexOf(lhs[i]);
+				if(ridx != -1) {
+					rhs1.splice(ridx, 1);
+					if(lidx != -1) {
+						lhs1.splice(lidx, 1);
+					}
+				}
+			}
+			lhs1.sort(function(a, b) {
+				return getOrderIndependentHash(a) - getOrderIndependentHash(b);
+			});
+ 
+			rhs1.sort(function(a, b) {
+				return getOrderIndependentHash(a) - getOrderIndependentHash(b);
+			});
+		}
+        var i, len = lhs1.length;
+        for (i = 0; i < lhs1.length; i++) {
+          if (i >= rhs1.length) {
+            changes(new DiffArray(currentPath, i, new DiffDeleted(undefined, lhs1[i])));
           } else {
-            deepDiff(lhs[i], rhs[i], changes, prefilter, currentPath, i, stack);
+            deepDiff(lhs1[i], rhs1[i], changes, prefilter, currentPath, i, stack, orderIndependent);
           }
         }
-        while (i < rhs.length) {
-          changes(new DiffArray(currentPath, i, new DiffNew(undefined, rhs[i++])));
+        while (i < rhs1.length) {
+          changes(new DiffArray(currentPath, i, new DiffNew(undefined, rhs1[i++])));
         }
       } else {
         var akeys = Object.keys(lhs);
@@ -179,14 +202,14 @@ function deepDiff(lhs, rhs, changes, prefilter, path, key, stack) {
         akeys.forEach(function(k, i) {
           var other = pkeys.indexOf(k);
           if (other >= 0) {
-            deepDiff(lhs[k], rhs[k], changes, prefilter, currentPath, k, stack);
+            deepDiff(lhs[k], rhs[k], changes, prefilter, currentPath, k, stack, orderIndependent);
             pkeys = arrayRemove(pkeys, other);
           } else {
-            deepDiff(lhs[k], undefined, changes, prefilter, currentPath, k, stack);
+            deepDiff(lhs[k], undefined, changes, prefilter, currentPath, k, stack, orderIndependent);
           }
         });
         pkeys.forEach(function(k) {
-          deepDiff(undefined, rhs[k], changes, prefilter, currentPath, k, stack);
+          deepDiff(undefined, rhs[k], changes, prefilter, currentPath, k, stack, orderIndependent);
         });
       }
       stack.length = stack.length - 1;
@@ -200,7 +223,9 @@ function deepDiff(lhs, rhs, changes, prefilter, path, key, stack) {
     }
   }
 }
-
+function orderIndependentDeepDiff(lhs, rhs, changes, prefilter, path, key, stack) {
+  return deepDiff(lhs, rhs, changes, prefilter, path, key, stack, true);
+}
 function accumulateDiff(lhs, rhs, prefilter, accum) {
   accum = accum || [];
   deepDiff(lhs, rhs,
@@ -212,7 +237,73 @@ function accumulateDiff(lhs, rhs, prefilter, accum) {
     prefilter);
   return (accum.length) ? accum : undefined;
 }
-
+function accumulateOrderIndependentDiff(lhs, rhs, prefilter, accum) {
+   accum = accum || [];
+   deepDiff(lhs, rhs,
+     function(diff) {
+       if (diff) {
+         accum.push(diff);
+       }
+     },
+     prefilter, null, null, null, true);
+   return (accum.length) ? accum : undefined;
+ }
+ function accumulateOrderIndependentDiff(lhs, rhs, prefilter, accum) {
+   accum = accum || [];
+   deepDiff(lhs, rhs,
+     function(diff) {
+       if (diff) {
+         accum.push(diff);
+       }
+     },
+     prefilter, null, null, null, true);
+   return (accum.length) ? accum : undefined;
+ }
+ 
+ // Gets a hash of the given object in an array order-independent fashion
+ // also object key order independent (easier since they can be alphabetized)
+ function getOrderIndependentHash(object) {
+   var accum = 0;
+   var type = realTypeOf(object);
+ 
+   if (type === 'array') {
+     object.forEach(function(item) {
+       // Addition is commutative so this is order indep
+       accum += getOrderIndependentHash(item);
+     });
+ 
+     var arrayString = '[type: array, hash: ' + accum + ']';
+     return accum + hashThisString(arrayString);
+   }
+ 
+   if (type === 'object') {
+     for (var key in object) {
+       if (object.hasOwnProperty(key)) {
+         var keyValueString = '[ type: object, key: ' + key + ', value hash: ' + getOrderIndependentHash(object[key]) + ']';
+         accum += hashThisString(keyValueString);
+       }
+     }
+ 
+     return accum;
+   }
+ 
+   // Non object, non array...should be good?
+   var stringToHash = '[ type: ' + type + ' ; value: ' + object + ']';
+   return accum + hashThisString(stringToHash);
+ }
+ 
+ // http://werxltd.com/wp/2010/05/13/javascript-implementation-of-javas-string-hashcode-method/
+ function hashThisString(string) {
+   var hash = 0;
+   if (string.length === 0) return hash;
+   for (var i = 0; i < string.length; i++) {
+     var char = string.charCodeAt(i);
+     hash = ((hash<<5)-hash)+char;
+     hash = hash & hash; // Convert to 32bit integer
+   }
+ 
+   return hash;
+ }
 function applyArrayChange(arr, index, change) {
   if (change.path && change.path.length) {
     var it = arr[index],
@@ -367,10 +458,22 @@ Object.defineProperties(accumulateDiff, {
     value: accumulateDiff,
     enumerable: true
   },
+  orderIndependentDiff: {
+    value: accumulateOrderIndependentDiff,
+    enumerable: true
+   },
   observableDiff: {
     value: deepDiff,
     enumerable: true
   },
+  orderIndependentObservableDiff: {
+     value:orderIndependentDeepDiff,
+     enumerable: true
+   },
+   orderIndepHash: {
+     value:getOrderIndependentHash,
+     enumerable: true
+   },
   applyDiff: {
     value: applyDiff,
     enumerable: true

--- a/index.es.js
+++ b/index.es.js
@@ -320,20 +320,10 @@ function accumulateOrderIndependentDiff(lhs, rhs, prefilter, accum) {
          accum.push(diff);
        }
      },
-     prefilter, null, null, null, true);
+     prefilter, undefined, undefined, undefined, true);
    return (accum.length) ? accum : undefined;
  }
- function accumulateOrderIndependentDiff(lhs, rhs, prefilter, accum) {
-   accum = accum || [];
-   deepDiff(lhs, rhs,
-     function(diff) {
-       if (diff) {
-         accum.push(diff);
-       }
-     },
-     prefilter, null, null, null, true);
-   return (accum.length) ? accum : undefined;
- }
+
  
  // Gets a hash of the given object in an array order-independent fashion
  // also object key order independent (easier since they can be alphabetized)

--- a/index.es.js
+++ b/index.es.js
@@ -18,8 +18,6 @@ if (conflict) {
     });
 }
 
-var ignoreOrder = false;
-
 // nodejs compatible on server side and in the browser.
 function inherits(ctor, superCtor) {
   ctor.super_ = superCtor;

--- a/index.es.js
+++ b/index.es.js
@@ -17,7 +17,84 @@ if (conflict) {
       }
     });
 }
+// Production steps of ECMA-262, Edition 6, 22.1.2.1
+if (!Array.from) {
+  Array.from = (function() {
+    var toStr = Object.prototype.toString;
+    var isCallable = function(fn) {
+      return typeof fn === 'function' || toStr.call(fn) === '[object Function]';
+    };
+    var toInteger = function(value) {
+      var number = Number(value);
+      if (isNaN(number)) { return 0; }
+      if (number === 0 || !isFinite(number)) { return number; }
+      return (number > 0 ? 1 : -1) * Math.floor(Math.abs(number));
+    };
+    var maxSafeInteger = Math.pow(2, 53) - 1;
+    var toLength = function(value) {
+      var len = toInteger(value);
+      return Math.min(Math.max(len, 0), maxSafeInteger);
+    };
 
+    // The length property of the from method is 1.
+    return function from(arrayLike/*, mapFn, thisArg */) {
+      // 1. Let C be the this value.
+      var C = this;
+
+      // 2. Let items be ToObject(arrayLike).
+      var items = Object(arrayLike);
+
+      // 3. ReturnIfAbrupt(items).
+      if (arrayLike === null) {
+        throw new TypeError('Array.from requires an array-like object - not null or undefined');
+      }
+
+      // 4. If mapfn is undefined, then let mapping be false.
+      var mapFn = arguments.length > 1 ? arguments[1] : void undefined;
+      var T;
+      if (typeof mapFn !== 'undefined') {
+        // 5. else
+        // 5. a If IsCallable(mapfn) is false, throw a TypeError exception.
+        if (!isCallable(mapFn)) {
+          throw new TypeError('Array.from: when provided, the second argument must be a function');
+        }
+
+        // 5. b. If thisArg was supplied, let T be thisArg; else let T be undefined.
+        if (arguments.length > 2) {
+          T = arguments[2];
+        }
+      }
+
+      // 10. Let lenValue be Get(items, "length").
+      // 11. Let len be ToLength(lenValue).
+      var len = toLength(items.length);
+
+      // 13. If IsConstructor(C) is true, then
+      // 13. a. Let A be the result of calling the [[Construct]] internal method 
+      // of C with an argument list containing the single item len.
+      // 14. a. Else, Let A be ArrayCreate(len).
+      var A = isCallable(C) ? Object(new C(len)) : new Array(len);
+
+      // 16. Let k be 0.
+      var k = 0;
+      // 17. Repeat, while k < len… (also steps a - h)
+      var kValue;
+      while (k < len) {
+        kValue = items[k];
+        if (mapFn) {
+          A[k] = typeof T === 'undefined' ? mapFn(kValue, k) : mapFn.call(T, kValue, k);
+        } else {
+          A[k] = kValue;
+        }
+        k += 1;
+      }
+      // 18. Let putStatus be Put(A, "length", len, true).
+      A.length = len;
+      // 20. Return A.
+      return A;
+    };
+  }());
+}
 // nodejs compatible on server side and in the browser.
 function inherits(ctor, superCtor) {
   ctor.super_ = superCtor;

--- a/index.js
+++ b/index.js
@@ -327,9 +327,10 @@ function accumulateOrderIndependentDiff(lhs, rhs, prefilter, accum) {
          accum.push(diff);
        }
      },
-     prefilter, null, null, null, true);
+     prefilter, undefined, undefined, undefined, true);
    return (accum.length) ? accum : undefined;
  }
+
  
  // Gets a hash of the given object in an array order-independent fashion
  // also object key order independent (easier since they can be alphabetized)

--- a/index.js
+++ b/index.js
@@ -24,7 +24,84 @@ if (conflict) {
       }
     });
 }
+// Production steps of ECMA-262, Edition 6, 22.1.2.1
+if (!Array.from) {
+  Array.from = (function() {
+    var toStr = Object.prototype.toString;
+    var isCallable = function(fn) {
+      return typeof fn === 'function' || toStr.call(fn) === '[object Function]';
+    };
+    var toInteger = function(value) {
+      var number = Number(value);
+      if (isNaN(number)) { return 0; }
+      if (number === 0 || !isFinite(number)) { return number; }
+      return (number > 0 ? 1 : -1) * Math.floor(Math.abs(number));
+    };
+    var maxSafeInteger = Math.pow(2, 53) - 1;
+    var toLength = function(value) {
+      var len = toInteger(value);
+      return Math.min(Math.max(len, 0), maxSafeInteger);
+    };
 
+    // The length property of the from method is 1.
+    return function from(arrayLike/*, mapFn, thisArg */) {
+      // 1. Let C be the this value.
+      var C = this;
+
+      // 2. Let items be ToObject(arrayLike).
+      var items = Object(arrayLike);
+
+      // 3. ReturnIfAbrupt(items).
+      if (arrayLike === null) {
+        throw new TypeError('Array.from requires an array-like object - not null or undefined');
+      }
+
+      // 4. If mapfn is undefined, then let mapping be false.
+      var mapFn = arguments.length > 1 ? arguments[1] : void undefined;
+      var T;
+      if (typeof mapFn !== 'undefined') {
+        // 5. else
+        // 5. a If IsCallable(mapfn) is false, throw a TypeError exception.
+        if (!isCallable(mapFn)) {
+          throw new TypeError('Array.from: when provided, the second argument must be a function');
+        }
+
+        // 5. b. If thisArg was supplied, let T be thisArg; else let T be undefined.
+        if (arguments.length > 2) {
+          T = arguments[2];
+        }
+      }
+
+      // 10. Let lenValue be Get(items, "length").
+      // 11. Let len be ToLength(lenValue).
+      var len = toLength(items.length);
+
+      // 13. If IsConstructor(C) is true, then
+      // 13. a. Let A be the result of calling the [[Construct]] internal method 
+      // of C with an argument list containing the single item len.
+      // 14. a. Else, Let A be ArrayCreate(len).
+      var A = isCallable(C) ? Object(new C(len)) : new Array(len);
+
+      // 16. Let k be 0.
+      var k = 0;
+      // 17. Repeat, while k < len… (also steps a - h)
+      var kValue;
+      while (k < len) {
+        kValue = items[k];
+        if (mapFn) {
+          A[k] = typeof T === 'undefined' ? mapFn(kValue, k) : mapFn.call(T, kValue, k);
+        } else {
+          A[k] = kValue;
+        }
+        k += 1;
+      }
+      // 18. Let putStatus be Put(A, "length", len, true).
+      A.length = len;
+      // 20. Return A.
+      return A;
+    };
+  }());
+}
 // nodejs compatible on server side and in the browser.
 function inherits(ctor, superCtor) {
   ctor.super_ = superCtor;

--- a/test/tests.js
+++ b/test/tests.js
@@ -618,9 +618,6 @@ describe('deep-diff', function() {
             expect(diff.length).to.be(1);
 
             expect(diff[0].kind).to.be('A');
-            expect(diff[0].path).to.be.an('array');
-            expect(diff[0].path).to.have.length(1);
-            expect(diff[0].path[0]).to.be(null);
             expect(diff[0].rhs).to.be(undefined);
 			expect(diff[0].item.kind).to.be('D');
 			expect(diff[0].item.lhs).to.be('1');

--- a/test/tests.js
+++ b/test/tests.js
@@ -606,6 +606,205 @@ describe('deep-diff', function() {
 
         });
     });
+	
+	describe('regression test for issue #100', function() {
+        var lhs = ['1', '2', '3', '4'];
+        var rhs = ['2', '3', '4'];
+
+        it('should detect that first element was deleted', function() {
+            var diff = deep.orderIndependentDiff(lhs, rhs);
+
+            expect(diff).to.be.an(Array);
+            expect(diff.length).to.be(1);
+
+            expect(diff[0].kind).to.be('A');
+            expect(diff[0].path).to.be.an('array');
+            expect(diff[0].path).to.have.length(1);
+            expect(diff[0].path[0]).to.be(null);
+            expect(diff[0].rhs).to.be(undefined);
+			expect(diff[0].item.kind).to.be('D');
+			expect(diff[0].item.lhs).to.be('1');
+
+			lhs = {id:'Release',phases:[{id:'Phase1',tasks:[{id:'Task1'},{id:'Task2'}]},{id:'Phase2',tasks:[{id:'Task3'}]}]};
+			rhs = {id:'Release',phases:[{id:'Phase2',tasks:[{id:'Task3'}]},{id:'Phase1',tasks:[{id:'Task1'},{id:'Task2'}]}]};
+			
+			diff = deep.orderIndependentDiff(lhs, rhs);
+			// there should not be any differences
+			expect(diff).to.be(undefined);
+		});
+	});
+	
+    describe('Order independent hash testing', function() {
+        function sameHash(a, b) {
+            expect(deep.orderIndepHash(a)).to.equal(deep.orderIndepHash(b));
+        }
+
+        function differentHash(a, b) {
+            expect(deep.orderIndepHash(a)).to.not.equal(deep.orderIndepHash(b));
+        }
+
+        describe('Order indepdendent hash function should give different values for different objects', function() {
+            it('should give different values for different "simple" types', function() {
+                differentHash(1, -20);
+                differentHash('foo', 45);
+                differentHash('pie', 'something else');
+                differentHash(1.3332, 1);
+                differentHash(1, null);
+                differentHash('this is kind of a long string, don\'t you think?', 'the quick brown fox jumped over the lazy doge');
+                differentHash(true, 2);
+                differentHash(false, 'flooog');
+            });
+
+            it('should give different values for string and object with string', function() {
+                differentHash('some string', { key: 'some string'});
+            });
+
+            it('should give different values for number and array', function() {
+                differentHash(1, [1]);
+            });
+
+            it('should give different values for string and array of string', function() {
+                differentHash('string', ['string']);
+            });
+
+            it('should give different values for boolean and object with boolean', function() {
+                differentHash(true, {key: true});
+            });
+
+            it('should give different values for different arrays', function() {
+                differentHash([1,2,3], [1,2]);
+                differentHash([1,4,5,6], ['foo', 1, true, undefined]);
+                differentHash([1,4,6], [1,4,7]);
+                differentHash([1,3,5], ['1', '3', '5']);
+            });
+
+            it('should give different values for different objects', function() {
+                differentHash({key: 'value'}, {other: 'value'});
+                differentHash({a: {b: 'c'}}, {a: 'b'});
+            });
+
+            it('should differentiate between arrays and objects', function() {
+                differentHash([1, true, '1'], {a: 1, b: true, c:'1'});
+            });
+        });
+
+        describe('Order independent hash function should work in pathological cases', function() {
+            it('should work in funky javascript cases', function() {
+                differentHash(undefined,null);
+                differentHash(0,undefined);
+                differentHash(0,null);
+                differentHash(0,false);
+                differentHash(0,[]);
+                differentHash('',[]);
+                differentHash(3.22, '3.22');
+                differentHash(true,'true');
+                differentHash(false,0);
+            });
+
+            it('should work on empty array and object', function() {
+                differentHash([], {});
+            });
+
+            it('should work on empty object and undefined', function() {
+                differentHash({}, undefined);
+            });
+
+            it('should work on empty array and array with 0', function() {
+                differentHash([], [0]);
+            });
+        });
+
+        describe('Order independent hash function should be order independent', function() {
+            it('should not care about array order', function() {
+                sameHash([1,2,3], [3,2,1]);
+                sameHash(['hi', true, 9.4], [true, 'hi', 9.4]);
+            });
+
+            it('should not care about key order in an object', function() {
+                sameHash({foo: 'bar', foz: 'baz'}, {foz: 'baz', foo: 'bar'});
+            });
+
+            it('should work with complicated objects', function() {
+                var obj1 = {
+                    foo: 'bar',
+                    faz: [
+                        1,
+                        'pie',
+                        {
+                            food: 'yum'
+                        }
+                    ]
+                };
+
+                var obj2 = {
+                    faz: [
+                        'pie',
+                        {
+                            food: 'yum'
+                        },
+                        1
+                    ],
+                    foo: 'bar'
+                };
+
+                sameHash(obj1, obj2);
+            });
+        });
+    });
 
 
+    describe('Order indepedent array comparison should work', function() {
+        it('can compare simple arrays in an order independent fashion', function() {
+            var lhs = [1, 2, 3];
+            var rhs = [1, 3, 2];
+
+            var diff = deep.orderIndependentDiff(lhs, rhs);
+            expect(diff).to.be(undefined);
+        });
+
+        it('still works with repeated elements', function() {
+            var lhs = [1, 1, 2];
+            var rhs = [1, 2, 1];
+
+            var diff = deep.orderIndependentDiff(lhs, rhs);
+            expect(diff).to.be(undefined);
+        });
+
+        it('works on complex objects', function() {
+            var obj1 = {
+                foo: 'bar',
+                faz: [
+                    1,
+                    'pie',
+                    {
+                        food: 'yum'
+                    }
+                ]
+            };
+
+            var obj2 = {
+                faz: [
+                    'pie',
+                    {
+                        food: 'yum'
+                    },
+                    1
+                ],
+                foo: 'bar'
+            };
+
+            var diff = deep.orderIndependentDiff(obj1, obj2);
+            expect(diff).to.be(undefined);
+        });
+
+        it ('should report some difference in non-equal arrays', function() {
+            var lhs = [1, 2, 3];
+            var rhs = [2, 2, 3];
+
+            var diff = deep.orderIndependentDiff(lhs, rhs);
+            expect(diff.length).to.be.ok();
+        });
+
+
+    });
 });


### PR DESCRIPTION
This modification is based on the work done in https://github.com/flitbit/diff/pull/101. I added logic to remove common objects between array to make sure a deletion result in 1 deletion change instead of numerous edition and 1 deletion. Ex:
lhs = [1,2,3,4]
rhs= [2,3,4]

should give [DiffArray{index: 0, item: DiffDeleted { lhs=1}}]
and not [DiffEdit{lhs: 2, rhs:1}, DiffEdit{lhs: 3, rhs:2}, DiffEdit{lhs: 4, rhs:3}, DiffArray{index: 3, item: DiffDeleted { lhs=4}}]