### PR TITLE
Don't call .hasOwnProperty; use Object.getOwnPropertyDescriptor instead.

### DIFF
--- a/index.es.js
+++ b/index.es.js
@@ -146,8 +146,8 @@ function deepDiff(lhs, rhs, changes, prefilter, path, key, stack) {
   var ltype = typeof lhs;
   var rtype = typeof rhs;
 
-  var ldefined = ltype !== 'undefined' || (stack && stack[stack.length - 1].lhs && stack[stack.length - 1].lhs.hasOwnProperty(key));
-  var rdefined = rtype !== 'undefined' || (stack && stack[stack.length - 1].rhs && stack[stack.length - 1].rhs.hasOwnProperty(key));
+  var ldefined = ltype !== 'undefined' || (stack && stack[stack.length - 1].lhs && Object.getOwnPropertyDescriptor(stack[stack.length - 1].lhs, key));
+  var rdefined = rtype !== 'undefined' || (stack && stack[stack.length - 1].rhs && Object.getOwnPropertyDescriptor(stack[stack.length - 1].rhs, key));
 
   if (!ldefined && rdefined) {
     changes(new DiffNew(currentPath, rhs));

--- a/index.es.js
+++ b/index.es.js
@@ -146,8 +146,8 @@ function deepDiff(lhs, rhs, changes, prefilter, path, key, stack) {
   var ltype = typeof lhs;
   var rtype = typeof rhs;
 
-  var ldefined = ltype !== 'undefined' || (stack && stack[stack.length - 1].lhs && Object.getOwnPropertyDescriptor(stack[stack.length - 1].lhs, key));
-  var rdefined = rtype !== 'undefined' || (stack && stack[stack.length - 1].rhs && Object.getOwnPropertyDescriptor(stack[stack.length - 1].rhs, key));
+  var ldefined = ltype !== 'undefined' || (stack.length && stack[stack.length - 1].lhs && Object.getOwnPropertyDescriptor(stack[stack.length - 1].lhs, key));
+  var rdefined = rtype !== 'undefined' || (stack.length && stack[stack.length - 1].rhs && Object.getOwnPropertyDescriptor(stack[stack.length - 1].rhs, key));
 
   if (!ldefined && rdefined) {
     changes(new DiffNew(currentPath, rhs));

--- a/index.js
+++ b/index.js
@@ -153,8 +153,8 @@ function deepDiff(lhs, rhs, changes, prefilter, path, key, stack) {
   var ltype = typeof lhs;
   var rtype = typeof rhs;
 
-  var ldefined = ltype !== 'undefined' || (stack && stack[stack.length - 1].lhs && stack[stack.length - 1].lhs.hasOwnProperty(key));
-  var rdefined = rtype !== 'undefined' || (stack && stack[stack.length - 1].rhs && stack[stack.length - 1].rhs.hasOwnProperty(key));
+  var ldefined = ltype !== 'undefined' || (stack && stack[stack.length - 1].lhs && Object.getOwnPropertyDescriptor(stack[stack.length - 1].lhs, key));
+  var rdefined = rtype !== 'undefined' || (stack && stack[stack.length - 1].rhs && Object.getOwnPropertyDescriptor(stack[stack.length - 1].rhs, key));
 
   if (!ldefined && rdefined) {
     changes(new DiffNew(currentPath, rhs));

--- a/index.js
+++ b/index.js
@@ -153,8 +153,8 @@ function deepDiff(lhs, rhs, changes, prefilter, path, key, stack) {
   var ltype = typeof lhs;
   var rtype = typeof rhs;
 
-  var ldefined = ltype !== 'undefined' || (stack && stack[stack.length - 1].lhs && Object.getOwnPropertyDescriptor(stack[stack.length - 1].lhs, key));
-  var rdefined = rtype !== 'undefined' || (stack && stack[stack.length - 1].rhs && Object.getOwnPropertyDescriptor(stack[stack.length - 1].rhs, key));
+  var ldefined = ltype !== 'undefined' || (stack.length && stack[stack.length - 1].lhs && Object.getOwnPropertyDescriptor(stack[stack.length - 1].lhs, key));
+  var rdefined = rtype !== 'undefined' || (stack.length && stack[stack.length - 1].rhs && Object.getOwnPropertyDescriptor(stack[stack.length - 1].rhs, key));
 
   if (!ldefined && rdefined) {
     changes(new DiffNew(currentPath, rhs));

--- a/test/tests.js
+++ b/test/tests.js
@@ -607,5 +607,29 @@ describe('deep-diff', function() {
         });
     });
 
+    describe('regression tests for issue #102', function() {
+        it('should not throw a TypeError', function() {
+
+            var diff = deep.diff(null, undefined);
+
+            expect(diff).to.be.an(Array);
+            expect(diff.length).to.be(1);
+
+            expect(diff[0].kind).to.be('D');
+            expect(diff[0].lhs).to.be(null);
+
+        });
+
+        it('should not throw a TypeError', function() {
+
+            var diff = deep.diff(Object.create(null), {foo: undefined});
+
+            expect(diff).to.be.an(Array);
+            expect(diff.length).to.be(1);
+
+            expect(diff[0].kind).to.be('N');
+            expect(diff[0].rhs).to.be(undefined);
+        });
+    });
 
 });


### PR DESCRIPTION
Fixes #102.