### PR TITLE
Plug global namespace leak.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
   if (typeof define === 'function' && define.amd) { // eslint-disable-line no-undef
     define([], factory);// eslint-disable-line no-undef
   } else if (typeof module === 'object' && module.exports) {
-    module.exports = factory();
+    module.exports = factory.call({});
   } else {
     root.returnExports = factory();
   }


### PR DESCRIPTION
Currently leaking `DeepDiff` into the global namespace when required by Node.js.