### PR TITLE
Fix the case when this/root is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -518,6 +518,9 @@
   // const DeepDiff = require('deep-diff');
   // const { DeepDiff } = require('deep-diff');
 
-  root.DeepDiff = accumulateDiff;
+  if (root) {
+    root.DeepDiff = accumulateDiff;
+  }
+
   return accumulateDiff;
 }));


### PR DESCRIPTION
Some combination of webpack and babel sometimes rewrites `this` to `void 0`:

![image](https://user-images.githubusercontent.com/324440/43516390-661c4ed2-957d-11e8-9596-4d2a1326c449.png)

Why is this line `root.DeepDiff = accumulateDiff;` needed at all, could it be removed?
