### PR TITLE
added tests for issue #141

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -580,6 +580,53 @@
       });
     });
 
+    describe('regression test for issue #141', function() {
+      var changeFail = { kind: 'E', path: ['foo'], lhs: true, rhs: false };
+      var changeSucceed = { kind: 'E', path: ['foo'], lhs: 1, rhs: 3 };
+
+      var revertLHSFalsey = { kind: 'E', path: ['foo'], lhs: -1, rhs: 1 };
+      var revertBothFalsey = { kind: 'E', path: ['foo'], lhs: -1, rhs: -3 };
+      var revertLHSTruthy = { kind: 'E', path: ['foo'], lhs: 1, rhs: 3 };
+      var revertBothTruthy = { kind: 'E', path: ['foo'], lhs: 1, rhs: 3 };
+
+      it('applies changes correctly when the new value is truthy', function() {
+        var target = { foo: changeSucceed.lhs };
+        deep.applyChange(target, changeSucceed);
+        expect(target.foo).to.equal(changeSucceed.rhs);
+      });
+
+      it('applies changes correctly when the new value is falsey', function() {
+        var target = { foo: changeFail.lhs };
+        deep.applyChange(target, changeFail);
+        expect(target.foo).to.equal(changeFail.rhs);
+      });
+
+      it('reverts changes correctly when both values are truthy', function() {
+        var target = { foo: 'hello' };
+        deep.revertChange(target, revertBothTruthy);
+        expect(target.foo).to.equal(revertBothTruthy.lhs);
+      });
+
+      it('reverts changes correctly when both values are falsey', function() {
+        var target = { foo: 'hello' };
+        deep.revertChange(target, revertBothFalsey);
+        expect(target.foo).to.equal(revertBothFalsey.lhs);
+      });
+
+      it('reverts changes correctly when the new value is truthy', function() {
+        var target = { foo: revertLHSTruthy.rhs };
+        deep.revertChange(target, revertLHSTruthy);
+        expect(target.foo).to.equal(revertLHSTruthy.lhs);
+      });
+
+      it('reverts changes correctly when the new value is falsey', function() {
+        var target = { foo: revertLHSFalsey.rhs };
+        deep.revertChange(target, revertLHSFalsey);
+        expect(target.foo).to.equal(revertLHSFalsey.lhs);
+      });
+
+    });
+
     describe('Order independent hash testing', function () {
       function sameHash(a, b) {
         expect(deep.orderIndepHash(a)).to.equal(deep.orderIndepHash(b));


### PR DESCRIPTION
While my findings don't totally agree with what's described in #141, they do show some bugs. In particular, it seems like revert doesn't work at all unless I'm misunderstanding how to use it, or I've made a JS variable memory-reference error).

Plus, I don't see any other tests for revert, so now there will be a few. 😄 

```
  83 passing (227ms)
  4 failing

  1) deep-diff
       regression test for issue #141
         reverts changes correctly when both values are truthy:
     Error: expected 'hello' to equal 1
      at Assertion.assert (node_modules/expect.js/index.js:96:13)
      at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
      at Context.<anonymous> (test/tests.js:607:31)

  2) deep-diff
       regression test for issue #141
         reverts changes correctly when both values are falsey:
     Error: expected 'hello' to equal -1
      at Assertion.assert (node_modules/expect.js/index.js:96:13)
      at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
      at Context.<anonymous> (test/tests.js:613:31)

  3) deep-diff
       regression test for issue #141
         reverts changes correctly when the new value is truthy:
     Error: expected 3 to equal 1
      at Assertion.assert (node_modules/expect.js/index.js:96:13)
      at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
      at Context.<anonymous> (test/tests.js:619:31)

  4) deep-diff
       regression test for issue #141
         reverts changes correctly when the new value is falsey:
     Error: expected 1 to equal -1
      at Assertion.assert (node_modules/expect.js/index.js:96:13)
      at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
      at Context.<anonymous> (test/tests.js:625:31)
```