### PR TITLE
added tests for issue #142

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -580,6 +580,23 @@
       });
     });
 
+    describe('regression tests for issue #102', function () {
+      it('should not modify the change object', function () {
+
+        var target = {};
+        var change1 = { kind: 'N', path: ['foo'], rhs: {} };
+        var change2 = { kind: 'N', path: ['foo', 'bar'], rhs: 'bug' };
+
+        deep.applyChange(target, true, change1);
+        deep.applyChange(target, true, change2);
+
+        expect(Object.keys(target)).to.eql(['foo']);
+        expect(Object.keys(target.foo)).to.eql(['bar']);
+        expect(Object.keys(change1.rhs)).to.eql([]);
+
+      });
+    });
+
     describe('Order independent hash testing', function () {
       function sameHash(a, b) {
         expect(deep.orderIndepHash(a)).to.equal(deep.orderIndepHash(b));

--- a/test/tests.js
+++ b/test/tests.js
@@ -580,7 +580,7 @@
       });
     });
 
-    describe('regression tests for issue #102', function () {
+    describe('regression tests for issue #142', function () {
       it('should not modify the change object', function () {
 
         var target = {};


### PR DESCRIPTION
It does appear that the change object can be modified when multiple are applied if one is an object.

```
  81 passing (94ms)
  1 failing

  1) deep-diff
       regression tests for issue #142
         should not modify the change object:

      Error: expected [ 'bar' ] to sort of equal []
      + expected - actual

      -[
      -  "bar"
      -]
      +[]

      at Assertion.assert (node_modules/expect.js/index.js:96:13)
      at Assertion.eql (node_modules/expect.js/index.js:230:10)
      at Context.<anonymous> (test/tests.js:595:45)
```