### PR TITLE
fix rhs object structure in observable diff

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -154,6 +154,7 @@ var rhs = {
     it: 'has',
     an: 'array',
     with: ['a', 'few', 'more', 'elements', { than: 'before' }]
+  }
 };
 
 observableDiff(lhs, rhs, function (d) {


### PR DESCRIPTION
There is a missing `}` in the the observable diff example