### PR TITLE
remove the source dependency from the revertChange function

### DIFF
--- a/index.js
+++ b/index.js
@@ -425,7 +425,7 @@
   }
 
   function revertChange(target, source, change) {
-    if (target && source && change && change.kind) {
+    if (target && change && change.kind) {
       var it = target,
         i, u;
       u = change.path.length - 1;


### PR DESCRIPTION
`source` was required in the `revertChange` function but unused. This is in conflict with README which says
>  NOTE: source is unused and may be removed.

However, when falsely the function will short circuit and never execute